### PR TITLE
Updated style to reflect typecase on dropdown menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3495,7 +3495,7 @@ td.cart-list-item-price {
   transition: color 0.2s ease;
   padding: 11px 0;
   font-size: 14px;
-  text-transform: uppercase;
+  text-transform: none;
   color: #ffffff;
 }
 .navigation-bar .dropdown-menu>li a:hover {


### PR DESCRIPTION
Dropdown menu had a uppercase fixed to it. Removed that to reflect uniform typecasing across the website.
